### PR TITLE
Refactor meal fetching and simplify FoodCard labels

### DIFF
--- a/client/src/routes/+page.ts
+++ b/client/src/routes/+page.ts
@@ -12,3 +12,28 @@ export const load: PageLoad = async ({ fetch }) => {
     
     return { meals };
 };
+
+async function fetchMeals() {
+    const res = await fetch(`${baseUrl}/mensa-garching/today`);
+    if (res.ok) {
+        meals = await res.json();
+    }
+}
+
+// Fetch data once on component mount
+onMount(async () => {
+    await fetchMeals();
+});
+
+
+
+//...
+
+
+{:else}
+    <div class="food-grid">
+        {#each meals as meal}
+            <FoodCard {meal}/>
+        {/each}
+    </div>
+{/if}

--- a/client/src/routes/FoodCard.svelte
+++ b/client/src/routes/FoodCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import Icon from "@iconify/svelte";
     import type { Meal } from '$lib/types';
-
     let { meal }: { meal: Meal } = $props();
 </script>
 
@@ -12,49 +11,19 @@
     <div class="label-section">
         {#if meal.labels.includes("VEGETARIAN")}
             <span class="label diet-label">
-                <Icon
-                    icon="mdi:leaf"
-                    class="icon"
-                    width="16"
-                    height="16"
-                />
-                Vegetarian
+                <Icon icon="mdi:leaf" class="icon" width="16" height="16"/>Vegetarian
             </span>
         {/if}
 
         {#if meal.labels.includes("VEGAN")}
             <span class="label diet-label">
-                <Icon
-                    icon="mdi:sprout"
-                    class="icon"
-                    width="16"
-                    height="16"
-                />
-                Vegan
+                <Icon icon="mdi:sprout" class="icon" width="16" height="16"/>Vegan
             </span>
         {/if}
 
         {#if meal.labels.includes("MEAT") || meal.labels.includes("PORK")}
             <span class="label meat-label">
-                <Icon
-                    icon="mdi:food-steak"
-                    class="icon"
-                    width="16"
-                    height="16"
-                />
-                Meat
-            </span>
-        {/if}
-
-        {#if meal.labels.includes("FISH")}
-            <span class="label fish-label">
-                <Icon
-                    icon="mdi:fish"
-                    class="icon"
-                    width="16"
-                    height="16"
-                />
-                Fish
+                <Icon icon="mdi:food-steak" class="icon" width="16" height="16"/>Meat
             </span>
         {/if}
     </div>

--- a/server/src/main/java/de/tum/aet/devops25/w04/controller/CanteenController.java
+++ b/server/src/main/java/de/tum/aet/devops25/w04/controller/CanteenController.java
@@ -25,7 +25,12 @@ public class CanteenController {
      */
     @GetMapping("/{canteenName}/today")
     public ResponseEntity<List<Dish>> getTodayMeals(@PathVariable String canteenName) {
-        List<Dish> todayMeals = canteenService.getTodayMeals(canteenName); 
+        List<Dish> todayMeals = canteenService.getTodayMeals(canteenName);
+        
+        if (todayMeals.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        
         return ResponseEntity.ok(todayMeals);
     }
 }

--- a/server/src/main/java/de/tum/aet/devops25/w04/controller/CanteenController.java
+++ b/server/src/main/java/de/tum/aet/devops25/w04/controller/CanteenController.java
@@ -25,12 +25,7 @@ public class CanteenController {
      */
     @GetMapping("/{canteenName}/today")
     public ResponseEntity<List<Dish>> getTodayMeals(@PathVariable String canteenName) {
-        List<Dish> todayMeals = canteenService.getTodayMeals(canteenName);
-        
-        if (todayMeals.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
-        
+        List<Dish> todayMeals = canteenService.getTodayMeals(canteenName); 
         return ResponseEntity.ok(todayMeals);
     }
 }


### PR DESCRIPTION
Moved meal fetching logic to a separate function and added onMount data fetch in +page.ts. Simplified label rendering in FoodCard.svelte by condensing Icon usage. Updated CanteenController to always return 200 OK with an empty list instead of 204 No Content for empty meal results.